### PR TITLE
Standardize words solution

### DIFF
--- a/custom solutions/Standardize Words Hook/README.md
+++ b/custom solutions/Standardize Words Hook/README.md
@@ -1,0 +1,11 @@
+### What it does
+
+It is a "before-incoming-middleware" hook that will changes words to standardize it
+
+Example: change "covid-19" or "covid 19" to "covid"
+
+### How to do it
+
+1 - Create a "before-incoming-middleware" hook using the script "standardise_word.js"
+
+2 - Change words in the "maps" object as needed

--- a/custom solutions/Standardize Words Hook/standardise_word.js
+++ b/custom solutions/Standardize Words Hook/standardise_word.js
@@ -1,0 +1,29 @@
+function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent) {
+  /** Your code starts below */
+  if (event.type !== "text") {
+    return;
+  }
+  const _ = require("lodash");
+  const maps = {
+    covid: [
+      /\bcoronavirus\b/gi,
+      /\bcorona\b/gi,
+      /\bcoronnavirus\b/gi,
+      /\bcarona\b/gi,
+      /\bcovid-19\b/gi,
+      /\bcovid19\b/gi,
+      /\bcovid 19\b/gi,
+      /\sars-cov-2\b/gi,
+      /\pandemic\b/gi,
+    ],
+  };
+  let phrase = event.preview;
+  _.entries(maps).forEach(([key, syn]) => {
+    syn.forEach((e) => {
+      phrase = phrase.toLowerCase().replace(e, key);
+    });
+  });
+  event.preview = phrase;
+  event.payload.text = phrase;
+  /** Your code ends here */
+}


### PR DESCRIPTION
It is a "before-incoming-middleware" hook that will changes words to standardize it

Example: change "covid-19" or "covid 19" to "covid"
