### PR TITLE
Break out of a flow on QNA match solution

### DIFF
--- a/custom solutions/Break out of flow when matching a QNA/README.md
+++ b/custom solutions/Break out of flow when matching a QNA/README.md
@@ -1,0 +1,7 @@
+### What it does
+
+Break out of a flow when a user message matches a QnA
+
+### How to do it
+
+use the code from the 'break-out-qna-hook.js' file to create a before_suggestions_election hook

--- a/custom solutions/Break out of flow when matching a QNA/break-out-qna-hook.js
+++ b/custom solutions/Break out of flow when matching a QNA/break-out-qna-hook.js
@@ -1,0 +1,38 @@
+function hook(
+  bp: typeof sdk,
+  sessionId: string,
+  event: sdk.IO.IncomingEvent,
+  suggestions: sdk.IO.Suggestion[]
+) {
+  /** Your code starts below */
+
+  async function hook() {
+    if (!suggestions.length || !suggestions[0].decision) {
+      return;
+    }
+    const suggestion = suggestions[0];
+    // maybe you don't want this triggering in every flow, or on every skill
+    if (!event.state.context.currentFlow.startsWith("skills/SFLiveAgent")) {
+      const decision = suggestion.decision;
+      if (
+        decision.status === "dropped" &&
+        decision.reason.includes("already in the middle of a flow") &&
+        suggestions[0].confidence > 0.5
+      ) {
+        // We're changing the election results
+        // The QnA will be answered to the user instead of continuing the flow
+        decision.status = "elected";
+        decision.reason = "Direct Q&A question detected - calling up answer.";
+        // and we are making the bot move into an action right after answering the
+        // users questions
+        suggestion.payloads = [
+          ...suggestion.payloads,
+          { type: "redirect", flow: "main.flow.json", node: "entry" },
+        ];
+      }
+    }
+  }
+  return hook();
+
+  /** Your code ends here */
+}


### PR DESCRIPTION
### What it does

Break out of a flow when a user message matches a QnA

### How to do it

use the code from the 'break-out-qna-hook.js' file to create a before_suggestions_election hook
