### PR TITLE
Add Dockerfile for image builder

### DIFF
--- a/custom_tools/bp_image_builder/Dockerfile
+++ b/custom_tools/bp_image_builder/Dockerfile
@@ -9,5 +9,7 @@ ADD tsconfig.json ./
 ADD src ./
 
 RUN yarn build
+ARG hook="docker_hooks/examples/Download train data from origin/after_build.sh"
+ADD ${hook} docker_hooks/after_build.sh
 
 CMD [ "yarn", "start" ]

--- a/custom_tools/bp_image_builder/Dockerfile
+++ b/custom_tools/bp_image_builder/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14-alpine
+
+WORKDIR /bp_image_builder
+
+ADD package.json yarn.lock ./
+RUN yarn install 
+
+ADD tsconfig.json ./
+ADD src ./
+
+RUN yarn build
+
+CMD [ "yarn", "start" ]

--- a/custom_tools/bp_image_builder/docker_hooks/examples/Download train data from origin/after_build.sh
+++ b/custom_tools/bp_image_builder/docker_hooks/examples/Download train data from origin/after_build.sh
@@ -20,7 +20,7 @@ fi
 file_index="$root/origin_files.json"
 header="Authorization: Bearer $BUILD_TOKEN"
 echo "Downloading origin files index from host $BUILD_ORIGIN_HOST"
-success=$(wget --header="$header" -O $file_index $BUILD_ORIGIN_HOST/api/v1/bots/bot2/mod/code-editor/files?rawFiles=true 2>&1 | grep -c '200 OK')
+success=$(wget --header="$header" -O $file_index $BUILD_ORIGIN_HOST/api/v1/bots/___/mod/code-editor/files?rawFiles=true 2>&1 | grep -c '200 OK')
 chmod 775 $file_index
 
 if [ ! $success = 1 ]; then 


### PR DESCRIPTION
It's much more preferable to use this tool dockerized on node14 instead of an outdated node12 binary with questionable installation path. 

Usage can require forwarding the docker socket into the container, e.g.: 

```sh
docker run -v /var/run/docker.sock:/var/run/docker.sock bp_image_builder sh -c "yarn start login <d> <u> <p>; yarn start build <d>"
```

Also you need extra host mappings around localhost if you want to develop this solution on locally on one machine:
```sh
docker run [...] --add-host <botpress.local>:<localNetworkIP> [...]
# e.g.
docker run [...] --add-host mybotpress.dev:192.168.0.5 [...]
```

Would you please release it on docker hub (can also be automated)?