### PR TITLE
Update get-slack-profile.js

### DIFF
--- a/custom solutions/Get user profile from Slack/actions/get-slack-profile.js
+++ b/custom solutions/Get user profile from Slack/actions/get-slack-profile.js
@@ -6,6 +6,8 @@ const axios = require('axios')
  * @category Slack
  */
 const extractInfo = async () => {
+  const config = await bp.bots.getBotById(event.botId)
+  const channels = config.messaging.channels
 
   if (event.channel !== 'slack' || !channels || !channels.teams) {
     return


### PR DESCRIPTION
channels was not defined; I stole these lines of code from the other `get user profile` solutions for Teams & Messenger.