### PR TITLE
Add default networkmode: 'host' to image baker buildImage.config.js

### DIFF
--- a/custom_tools/bp_image_builder/custom_buildImage_config/buildImage.config.js
+++ b/custom_tools/bp_image_builder/custom_buildImage_config/buildImage.config.js
@@ -1,6 +1,8 @@
 module.exports = async () => {
     return  {
-        nocache: true
+        nocache: true,
+        networkmode: 'host', // recommended as default, so building also works for local deployments
+        // for all other possible values, see: https://docs.docker.com/engine/api/v1.37/#operation/ImageBuild
     }
 }
  


### PR DESCRIPTION
As recommended by @davidvitora, proposing this as a contribution to my latest findings
```yml
# Baker compose
extra_hosts:
      - ${HOST_NAME_BOTPRESS_CMS}:host-gateway
```
In conjunction with this host-gateway mapping, the custom image builder "baker" tool works dockerized on developers workstations, this networking config enables it to reach local Botpress deployments.

Maybe I should also add a full compose file as an example?