### PR TITLE
Fix typo in built image env BPFS_STORAGE

### DIFF
--- a/custom_tools/bp_image_builder/src/utils.ts
+++ b/custom_tools/bp_image_builder/src/utils.ts
@@ -58,7 +58,7 @@ export function makeDockerfile(
             : ""
         }
         WORKDIR /botpress
-        ENV BPFS=disk \
+        ENV BPFS_STORAGE=disk \
             CORE_DISABLE_FILE_LISTENERS=true
         CMD ./duckling & ./bp
     `;


### PR DESCRIPTION
Follow up on https://github.com/botpress/solutions/pull/39
I was using and abbreviating this as "BPFS" without the "_STORAGE" postfix in discussions, sorry. 