### PR TITLE
Add threadId / conversationId to new message event

### DIFF
--- a/custom solutions/Send message to user using API [Intersection API]/hooks/after_server_start/createIntersectionAPI.js
+++ b/custom solutions/Send message to user using API [Intersection API]/hooks/after_server_start/createIntersectionAPI.js
@@ -36,6 +36,7 @@
       const event = bp.IO.Event({
         direction: 'outgoing',
         channel: channel,
+        threadId: threadId,
         botId,
         target,
         type,


### PR DESCRIPTION
Add threadId / conversationId to new message event, previous implementation is throwing a 400 error with 'conversationId required' on newer versions of BP.